### PR TITLE
Mirror of cisco mlspp#91

### DIFF
--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -10,14 +10,13 @@
 using namespace mls;
 
 const auto suite = CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
-const auto scheme = SignatureScheme::Ed25519;
 
 class User
 {
 public:
   User(const std::string& name)
   {
-    _identity_priv = SignaturePrivateKey::generate(scheme);
+    _identity_priv = SignaturePrivateKey::generate(suite);
     auto id = bytes(name.begin(), name.end());
     _cred = Credential::basic(id, _identity_priv.public_key());
   }

--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -9,7 +9,7 @@
 
 using namespace mls;
 
-const auto suite = CipherSuite::X25519_SHA256_AES128GCM;
+const auto suite = CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
 const auto scheme = SignatureScheme::Ed25519;
 
 class User

--- a/cmd/simulator/main.cpp
+++ b/cmd/simulator/main.cpp
@@ -225,7 +225,7 @@ public:
 int
 main(int argc, char** argv)
 {
-  const auto suite = mls::CipherSuite::X25519_SHA256_AES128GCM;
+  const auto suite = mls::CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
   const auto scheme = mls::SignatureScheme::Ed25519;
 
   if (argc < 2) {

--- a/cmd/simulator/main.cpp
+++ b/cmd/simulator/main.cpp
@@ -122,13 +122,11 @@ class Simulation
 {
 private:
   mls::CipherSuite suite;
-  mls::SignatureScheme scheme;
   std::vector<std::optional<mls::Session>> sessions;
 
 public:
-  Simulation(mls::CipherSuite suite_in, mls::SignatureScheme scheme_in)
+  Simulation(mls::CipherSuite suite_in)
     : suite(suite_in)
-    , scheme(scheme_in)
   {}
 
   mls::bytes random() const { return mls::random_bytes(32); }
@@ -137,7 +135,7 @@ public:
   {
     auto secret = mls::random_bytes(32);
     auto init = mls::HPKEPrivateKey::derive(suite, secret);
-    auto priv = mls::SignaturePrivateKey::generate(scheme);
+    auto priv = mls::SignaturePrivateKey::generate(suite);
     auto id = random();
     auto cred = mls::Credential::basic(id, priv.public_key());
     auto kp = mls::KeyPackage{ suite, init.public_key(), cred, priv };
@@ -226,7 +224,6 @@ int
 main(int argc, char** argv)
 {
   const auto suite = mls::CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
-  const auto scheme = mls::SignatureScheme::Ed25519;
 
   if (argc < 2) {
     std::cout << "Usage: simulator <script.json>" << std::endl;
@@ -237,7 +234,7 @@ main(int argc, char** argv)
   auto script = json::parse(script_json).get<Script>();
 
   // Initialize a set of sessions
-  Simulation sim(suite, scheme);
+  Simulation sim(suite);
   sim.init(script.initial_size);
 
   // Follow the steps in the script

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -578,8 +578,6 @@ main()
   verify_reproducible(generate_tree_math);
   verify_reproducible(generate_hash_ratchet);
   verify_reproducible(generate_key_schedule);
-  verify_reproducible(generate_messages);
-  verify_session_repro(generate_basic_session);
 
   // Verify that the test vectors load
   try {

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -319,13 +319,16 @@ generate_messages()
     direct_path.leaf_key_package.signature = tv.random;
 
     // Construct CIK
+    auto ext_list =
+      ExtensionList{ { { ExtensionType::lifetime, bytes(8, 0) } } };
     auto key_package =
       KeyPackage{ suite, dh_priv.public_key(), cred, sig_priv };
+    key_package.extensions = ext_list;
     key_package.signature = tv.random;
 
     // Construct Welcome
-    auto group_info =
-      GroupInfo{ tv.group_id, tv.epoch, tree, tv.random, tv.random, tv.random };
+    auto group_info = GroupInfo{ tv.group_id, tv.epoch, tree,     tv.random,
+                                 tv.random,   ext_list, tv.random };
     group_info.signer_index = tv.signer_index;
     group_info.signature = tv.random;
 

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -56,8 +56,8 @@ generate_crypto()
   CryptoTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   tv.hkdf_extract_salt = { 0, 1, 2, 3 };
@@ -95,8 +95,8 @@ generate_hash_ratchet()
   HashRatchetTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   tv.n_members = 16;
@@ -129,8 +129,8 @@ generate_key_schedule()
   KeyScheduleTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   GroupContext base_group_context{
@@ -211,8 +211,8 @@ generate_treekem()
   TreeKEMTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   std::vector<SignatureScheme> schemes{
@@ -272,8 +272,8 @@ generate_messages()
   MessagesTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   std::vector<SignatureScheme> schemes{
@@ -403,10 +403,10 @@ generate_basic_session()
   BasicSessionTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   std::vector<SignatureScheme> schemes{

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -215,11 +215,6 @@ generate_treekem()
     CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
-  std::vector<SignatureScheme> schemes{
-    SignatureScheme::P256_SHA256,
-    SignatureScheme::Ed25519,
-  };
-
   size_t n_leaves = 10;
   tv.init_secrets.resize(n_leaves);
   tv.leaf_secrets.resize(n_leaves);
@@ -230,11 +225,9 @@ generate_treekem()
 
   for (size_t i = 0; i < suites.size(); ++i) {
     auto suite = suites[i];
-    auto scheme = schemes[i];
 
     TreeKEMTestVectors::TestCase tc;
     tc.cipher_suite = suite;
-    tc.signature_scheme = scheme;
 
     TreeKEMPublicKey tree{ suite };
 
@@ -243,7 +236,7 @@ generate_treekem()
       auto context = bytes{ uint8_t(i), uint8_t(j) };
       auto init_priv = HPKEPrivateKey::derive(suite, tv.init_secrets[j].data);
       auto sig_priv =
-        SignaturePrivateKey::derive(scheme, tv.init_secrets[j].data);
+        SignaturePrivateKey::derive(suite, tv.init_secrets[j].data);
       auto cred = Credential::basic(context, sig_priv.public_key());
       auto kp = KeyPackage{ suite, init_priv.public_key(), cred, sig_priv };
 
@@ -276,11 +269,6 @@ generate_messages()
     CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
-  std::vector<SignatureScheme> schemes{
-    SignatureScheme::P256_SHA256,
-    SignatureScheme::Ed25519,
-  };
-
   // Set the inputs
   tv.epoch = 0xA0A1A2A3;
   tv.signer_index = LeafIndex{ 0xB0B1B2B3 };
@@ -296,18 +284,16 @@ generate_messages()
   DeterministicHPKE lock;
   for (size_t i = 0; i < suites.size(); ++i) {
     auto suite = suites[i];
-    auto scheme = schemes[i];
 
     // Miscellaneous data items we need to construct messages
     auto dh_priv = HPKEPrivateKey::derive(suite, tv.dh_seed);
     auto dh_key = dh_priv.public_key();
-    auto sig_priv = SignaturePrivateKey::derive(scheme, tv.sig_seed);
+    auto sig_priv = SignaturePrivateKey::derive(suite, tv.sig_seed);
     auto sig_key = sig_priv.public_key();
     auto cred = Credential::basic(tv.user_id, sig_priv.public_key());
 
     auto tree = TestTreeKEMPublicKey{
       suite,
-      scheme,
       { tv.random, tv.random, tv.random, tv.random },
     };
     tree.blank_path(LeafIndex{ 2 });
@@ -374,7 +360,6 @@ generate_messages()
     };
 
     tv.cases.push_back({ suite,
-                         scheme,
                          tls::marshal(key_package),
                          tls::marshal(group_info),
                          tls::marshal(group_secrets),
@@ -409,13 +394,6 @@ generate_basic_session()
     CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
-  std::vector<SignatureScheme> schemes{
-    SignatureScheme::P256_SHA256,
-    SignatureScheme::P256_SHA256,
-    SignatureScheme::Ed25519,
-    SignatureScheme::Ed25519,
-  };
-
   std::vector<bool> encrypts{ false, true, false, true };
 
   tv.group_size = 5;
@@ -424,7 +402,6 @@ generate_basic_session()
   DeterministicHPKE lock;
   for (size_t i = 0; i < suites.size(); ++i) {
     auto suite = suites[i];
-    auto scheme = schemes[i];
     auto encrypt = encrypts[i];
     const bytes key_package_id = { 0, 1, 2, 3 };
     const bytes group_init_secret = { 4, 5, 6, 7 };
@@ -438,7 +415,7 @@ generate_basic_session()
     auto ciphersuites = std::vector<CipherSuite>{ suite };
     for (size_t j = 0; j < tv.group_size; ++j) {
       auto init_secret = bytes{ uint8_t(j), 0 };
-      auto identity_priv = SignaturePrivateKey::derive(scheme, init_secret);
+      auto identity_priv = SignaturePrivateKey::derive(suite, init_secret);
       auto cred = Credential::basic(init_secret, identity_priv.public_key());
       auto init = HPKEPrivateKey::derive(suite, init_secret);
       auto kp = KeyPackage{ suite, init.public_key(), cred, identity_priv };
@@ -504,7 +481,7 @@ generate_basic_session()
     }
 
     // Construct the test case
-    tv.cases.push_back({ suite, scheme, encrypt, key_packages, transcript });
+    tv.cases.push_back({ suite, encrypt, key_packages, transcript });
   }
 
   return tv;
@@ -555,7 +532,7 @@ verify_session_repro(const F& generator)
 
   for (size_t i = 0; i < v0.cases.size(); ++i) {
     // Randomized signatures break reproducibility
-    if (!deterministic_signature_scheme(v0.cases[i].signature_scheme)) {
+    if (!deterministic_signature_scheme(v0.cases[i].cipher_suite)) {
       continue;
     }
 

--- a/include/common.h
+++ b/include/common.h
@@ -59,24 +59,27 @@ operator!=(const T& lhs, const T& rhs) {
 
 enum struct CipherSuite : uint16_t
 {
-  P256_SHA256_AES128GCM = 0x0000,
-  P521_SHA512_AES256GCM = 0x0010,
-  X25519_SHA256_AES128GCM = 0x0001,
-  X448_SHA512_AES256GCM = 0x0011,
-  unknown = 0xffff,
+  unknown = 0x0000,
+  X25519_AES128GCM_SHA256_Ed25519 = 0x0001,
+  P256_AES128GCM_SHA256_P256 = 0x0002,
+  X25519_CHACHA20POLY1305_SHA256_Ed25519 = 0x0003, // Unsupported
+  X448_AES256GCM_SHA512_Ed448 = 0x0004,
+  P521_AES256GCM_SHA512_P521 = 0x0005,
+  X448_CHACHA20POLY1305_SHA512_Ed448 = 0x0006, // Unsupported
 };
-
-size_t suite_nonce_size(CipherSuite suite);
-size_t suite_key_size(CipherSuite suite);
 
 enum struct SignatureScheme : uint16_t
 {
+  unknown = 0x0000,
   P256_SHA256 = 0x0403,
   P521_SHA512 = 0x0603,
   Ed25519 = 0x0807,
   Ed448 = 0x0808,
-  unknown = 0xffff,
 };
+
+SignatureScheme suite_signature_scheme(CipherSuite suite);
+size_t suite_nonce_size(CipherSuite suite);
+size_t suite_key_size(CipherSuite suite);
 
 ///
 /// Error types

--- a/include/common.h
+++ b/include/common.h
@@ -38,6 +38,12 @@ operator<<(std::ostream& out, const bytes& data);
 using epoch_t = uint64_t;
 
 ///
+/// Get the current system clock time in the format MLS expects
+///
+
+uint64_t seconds_since_epoch();
+
+///
 /// Auto-generate equality and inequality operators for TLS-serializable things
 ///
 

--- a/include/common.h
+++ b/include/common.h
@@ -77,6 +77,7 @@ enum struct SignatureScheme : uint16_t
   Ed448 = 0x0808,
 };
 
+extern const std::array<CipherSuite, 4> all_supported_suites;
 SignatureScheme suite_signature_scheme(CipherSuite suite);
 size_t suite_nonce_size(CipherSuite suite);
 size_t suite_key_size(CipherSuite suite);

--- a/include/core_types.h
+++ b/include/core_types.h
@@ -28,8 +28,8 @@ struct Extension {
   ExtensionType type;
   bytes data;
 
-  TLS_SERIALIZABLE(type, data);
-  TLS_TRAITS(tls::pass, tls::vector<2>);
+  TLS_SERIALIZABLE(type, data)
+  TLS_TRAITS(tls::pass, tls::vector<2>)
 };
 
 struct ExtensionList {
@@ -65,24 +65,24 @@ struct ExtensionList {
 
   bool has(ExtensionType type) const;
 
-  TLS_SERIALIZABLE(extensions);
-  TLS_TRAITS(tls::vector<2>);
+  TLS_SERIALIZABLE(extensions)
+  TLS_TRAITS(tls::vector<2>)
 };
 
 struct SupportedVersionsExtension {
   std::vector<ProtocolVersion> versions;
 
   static const ExtensionType type;
-  TLS_SERIALIZABLE(versions);
-  TLS_TRAITS(tls::vector<1>);
+  TLS_SERIALIZABLE(versions)
+  TLS_TRAITS(tls::vector<1>)
 };
 
 struct SupportedCipherSuitesExtension {
   std::vector<CipherSuite> cipher_suites;
 
   static const ExtensionType type;
-  TLS_SERIALIZABLE(cipher_suites);
-  TLS_TRAITS(tls::vector<1>);
+  TLS_SERIALIZABLE(cipher_suites)
+  TLS_TRAITS(tls::vector<1>)
 };
 
 struct LifetimeExtension {
@@ -90,23 +90,23 @@ struct LifetimeExtension {
   uint64_t not_after;
 
   static const ExtensionType type;
-  TLS_SERIALIZABLE(not_before, not_after);
+  TLS_SERIALIZABLE(not_before, not_after)
 };
 
 struct KeyIDExtension {
   bytes key_id;
 
   static const ExtensionType type;
-  TLS_SERIALIZABLE(key_id);
-  TLS_TRAITS(tls::vector<2>);
+  TLS_SERIALIZABLE(key_id)
+  TLS_TRAITS(tls::vector<2>)
 };
 
 struct ParentHashExtension {
   bytes parent_hash;
 
   static const ExtensionType type;
-  TLS_SERIALIZABLE(parent_hash);
-  TLS_TRAITS(tls::vector<1>);
+  TLS_SERIALIZABLE(parent_hash)
+  TLS_TRAITS(tls::vector<1>)
 };
 
 ///
@@ -160,9 +160,7 @@ struct KeyPackage
   void sign(const SignaturePrivateKey& sig_priv,
             const std::optional<KeyPackageOpts>& opts);
 
-  bool verify_basic_extensions(ProtocolVersion version,
-                               CipherSuite suite,
-                               uint64_t now) const;
+  bool verify_expiry(uint64_t now) const;
   bool verify_extension_support(const ExtensionList& ext_list) const;
   bool verify() const;
 

--- a/include/core_types.h
+++ b/include/core_types.h
@@ -134,7 +134,7 @@ struct KeyPackage
   CipherSuite cipher_suite;
   HPKEPublicKey init_key;
   Credential credential;
-  // TODO Extensions
+  ExtensionList extensions;
   bytes signature;
 
   KeyPackage();
@@ -150,8 +150,8 @@ struct KeyPackage
   bool verify() const;
 
   static const NodeType type;
-  TLS_SERIALIZABLE(version, cipher_suite, init_key, credential, signature)
-  TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::pass, tls::vector<2>)
+  TLS_SERIALIZABLE(version, cipher_suite, init_key, credential, extensions, signature)
+  TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::pass, tls::pass, tls::vector<2>)
 
   private:
   bytes to_be_signed() const;

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -134,8 +134,9 @@ class SignaturePublicKey
 {
 public:
   SignaturePublicKey();
-  SignaturePublicKey(SignatureScheme scheme, bytes data);
+  SignaturePublicKey(CipherSuite suite, bytes data);
 
+  void set_cipher_suite(CipherSuite suite);
   void set_signature_scheme(SignatureScheme scheme);
   SignatureScheme signature_scheme() const;
   bool verify(const bytes& message, const bytes& signature) const;
@@ -154,9 +155,9 @@ class SignaturePrivateKey
 public:
   SignaturePrivateKey();
 
-  static SignaturePrivateKey generate(SignatureScheme scheme);
-  static SignaturePrivateKey parse(SignatureScheme scheme, const bytes& data);
-  static SignaturePrivateKey derive(SignatureScheme scheme,
+  static SignaturePrivateKey generate(CipherSuite suite);
+  static SignaturePrivateKey parse(CipherSuite suite, const bytes& data);
+  static SignaturePrivateKey derive(CipherSuite suite,
                                     const bytes& secret);
 
   bytes sign(const bytes& message) const;
@@ -166,11 +167,12 @@ public:
   TLS_TRAITS(tls::pass, tls::vector<2>, tls::vector<2>)
 
 private:
+  CipherSuite _suite;
   SignatureScheme _scheme;
   bytes _data;
   bytes _pub_data;
 
-  SignaturePrivateKey(SignatureScheme scheme, const bytes& data);
+  SignaturePrivateKey(CipherSuite suite, const bytes& data);
 };
 
 } // namespace mls

--- a/include/messages.h
+++ b/include/messages.h
@@ -12,18 +12,15 @@
 namespace mls {
 
 // struct {
-//   // GroupContext inputs
 //   opaque group_id<0..255>;
-//   uint32 epoch;
-//   optional<RatchetNode> tree<1..2^32-1>;
+//   uint64 epoch;
+//   optional<Node> tree<1..2^32-1>;
 //   opaque confirmed_transcript_hash<0..255>;
-//
-//   // Inputs to the next round of the key schedule
 //   opaque interim_transcript_hash<0..255>;
-//   opaque epoch_secret<0..255>;
-//
+//   Extension extensions<0..2^16-1>;
+//   opaque confirmation<0..255>
 //   uint32 signer_index;
-//   opaque signature<0..255>;
+//   opaque signature<0..2^16-1>;
 // } GroupInfo;
 struct GroupInfo {
   bytes group_id;
@@ -32,8 +29,9 @@ struct GroupInfo {
 
   bytes confirmed_transcript_hash;
   bytes interim_transcript_hash;
-  bytes confirmation;
+  ExtensionList extensions;
 
+  bytes confirmation;
   LeafIndex signer_index;
   bytes signature;
 
@@ -43,6 +41,7 @@ struct GroupInfo {
             TreeKEMPublicKey tree_in,
             bytes confirmed_transcript_hash_in,
             bytes interim_transcript_hash_in,
+            ExtensionList extensions_in,
             bytes confirmation_in);
 
   bytes to_be_signed() const;
@@ -54,6 +53,7 @@ struct GroupInfo {
                    tree,
                    confirmed_transcript_hash,
                    interim_transcript_hash,
+                   extensions,
                    confirmation,
                    signer_index,
                    signature)
@@ -62,6 +62,7 @@ struct GroupInfo {
              tls::pass,
              tls::vector<1>,
              tls::vector<1>,
+             tls::pass,
              tls::vector<1>,
              tls::pass,
              tls::vector<2>)

--- a/include/state.h
+++ b/include/state.h
@@ -12,10 +12,11 @@
 namespace mls {
 
 // struct {
-//   opaque group_id<0..255>;
-//   uint32 epoch;
-//   opaque tree_hash<0..255>;
-//   opaque transcript_hash<0..255>;
+//     opaque group_id<0..255>;
+//     uint64 epoch;
+//     opaque tree_hash<0..255>;
+//     opaque confirmed_transcript_hash<0..255>;
+//     Extension extensions<0..2^16-1>;
 // } GroupContext;
 struct GroupContext
 {
@@ -23,9 +24,10 @@ struct GroupContext
   epoch_t epoch;
   bytes tree_hash;
   bytes confirmed_transcript_hash;
+  ExtensionList extensions;
 
-  TLS_SERIALIZABLE(group_id, epoch, tree_hash, confirmed_transcript_hash)
-  TLS_TRAITS(tls::vector<1>, tls::pass, tls::vector<1>, tls::vector<1>)
+  TLS_SERIALIZABLE(group_id, epoch, tree_hash, confirmed_transcript_hash, extensions)
+  TLS_TRAITS(tls::vector<1>, tls::pass, tls::vector<1>, tls::vector<1>, tls::pass)
 };
 
 class State
@@ -92,6 +94,7 @@ protected:
   TreeKEMPrivateKey _tree_priv;
   bytes _confirmed_transcript_hash;
   bytes _interim_transcript_hash;
+  ExtensionList _extensions;
 
   // Shared secret state
   KeyScheduleEpoch _keys;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -67,6 +67,14 @@ operator^(const bytes& lhs, const bytes& rhs)
   return out;
 }
 
+uint64_t
+seconds_since_epoch()
+{
+  auto since_epoch = std::chrono::system_clock::now().time_since_epoch();
+  auto secs = std::chrono::duration_cast<std::chrono::seconds>(since_epoch);
+  return secs.count();
+}
+
 std::ostream&
 operator<<(std::ostream& out, const bytes& data)
 {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -80,6 +80,13 @@ operator<<(std::ostream& out, const bytes& data)
   return out << to_hex(abbrev) << "...";
 }
 
+const std::array<CipherSuite, 4> all_supported_suites = {
+  CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
+  CipherSuite::P256_AES128GCM_SHA256_P256,
+  CipherSuite::X448_AES256GCM_SHA512_Ed448,
+  CipherSuite::P521_AES256GCM_SHA512_P521,
+};
+
 SignatureScheme
 suite_signature_scheme(CipherSuite suite)
 {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -80,14 +80,32 @@ operator<<(std::ostream& out, const bytes& data)
   return out << to_hex(abbrev) << "...";
 }
 
+SignatureScheme
+suite_signature_scheme(CipherSuite suite)
+{
+  switch (suite) {
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+      return SignatureScheme::Ed25519;
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+      return SignatureScheme::P256_SHA256;
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+      return SignatureScheme::Ed448;
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
+      return SignatureScheme::P521_SHA512;
+
+    default:
+      throw InvalidParameterError("Unsupported ciphersuite");
+  }
+}
+
 size_t
 suite_nonce_size(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
-    case CipherSuite::P521_SHA512_AES256GCM:
-    case CipherSuite::X25519_SHA256_AES128GCM:
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
       return 12;
 
     default:
@@ -99,12 +117,12 @@ size_t
 suite_key_size(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
-    case CipherSuite::X25519_SHA256_AES128GCM:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
       return 16;
 
-    case CipherSuite::P521_SHA512_AES256GCM:
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
       return 32;
 
     default:

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -70,9 +70,9 @@ operator^(const bytes& lhs, const bytes& rhs)
 uint64_t
 seconds_since_epoch()
 {
-  auto since_epoch = std::chrono::system_clock::now().time_since_epoch();
-  auto secs = std::chrono::duration_cast<std::chrono::seconds>(since_epoch);
-  return secs.count();
+  // TODO(RLB) This should use std::chrono, but that seems not to be available
+  // on some platforms.
+  return std::time(nullptr);
 }
 
 std::ostream&

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -88,11 +88,7 @@ KeyPackage::verify_expiry(uint64_t now) const
   }
 
   auto& lt = maybe_lt.value();
-  if (now < lt.not_before || now > lt.not_after) {
-    return false;
-  }
-
-  return true;
+  return lt.not_before <= now && now <= lt.not_after;
 }
 
 bool

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -2,6 +2,22 @@
 
 namespace mls {
 
+///
+/// Extensions
+///
+
+const ExtensionType SupportedVersionsExtension::type =
+  ExtensionType::supported_versions;
+const ExtensionType SupportedCipherSuitesExtension::type =
+  ExtensionType::supported_ciphersuites;
+const ExtensionType LifetimeExtension::type = ExtensionType::lifetime;
+const ExtensionType KeyIDExtension::type = ExtensionType::key_id;
+const ExtensionType ParentHashExtension::type = ExtensionType::parent_hash;
+
+///
+/// NodeType, ParentNode, and KeyPackage
+///
+
 const NodeType KeyPackage::type = NodeType::leaf;
 
 KeyPackage::KeyPackage()
@@ -64,7 +80,9 @@ operator==(const KeyPackage& lhs, const KeyPackage& rhs)
   return tbs && (ver || same);
 }
 
-// DirectPath
+///
+/// DirectPath
+///
 
 void
 DirectPath::sign(CipherSuite suite,

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -80,33 +80,8 @@ KeyPackage::sign(const SignaturePrivateKey& sig_priv,
 }
 
 bool
-KeyPackage::verify_basic_extensions(ProtocolVersion version,
-                                    CipherSuite suite,
-                                    uint64_t now) const
+KeyPackage::verify_expiry(uint64_t now) const
 {
-  // Verify version support
-  auto maybe_sv = extensions.find<SupportedVersionsExtension>();
-  if (!maybe_sv.has_value()) {
-    return false;
-  }
-
-  auto& sv = maybe_sv.value().versions;
-  if (std::find(sv.begin(), sv.end(), version) == sv.end()) {
-    return false;
-  }
-
-  // Verify ciphersuite support
-  auto maybe_sc = extensions.find<SupportedCipherSuitesExtension>();
-  if (!maybe_sc.has_value()) {
-    return false;
-  }
-
-  auto& sc = maybe_sc.value().cipher_suites;
-  if (std::find(sc.begin(), sc.end(), suite) == sc.end()) {
-    return false;
-  }
-
-  // Verify expiry
   auto maybe_lt = extensions.find<LifetimeExtension>();
   if (!maybe_lt.has_value()) {
     return false;

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -416,8 +416,8 @@ SignaturePublicKey::SignaturePublicKey()
   : _scheme(SignatureScheme::unknown)
 {}
 
-SignaturePublicKey::SignaturePublicKey(SignatureScheme scheme, bytes data)
-  : _scheme(scheme)
+SignaturePublicKey::SignaturePublicKey(CipherSuite suite, bytes data)
+  : _scheme(suite_signature_scheme(suite))
   , _data(std::move(data))
 {}
 
@@ -425,6 +425,12 @@ void
 SignaturePublicKey::set_signature_scheme(SignatureScheme scheme)
 {
   _scheme = scheme;
+}
+
+void
+SignaturePublicKey::set_cipher_suite(CipherSuite suite)
+{
+  _scheme = suite_signature_scheme(suite);
 }
 
 SignatureScheme
@@ -450,21 +456,23 @@ SignaturePrivateKey::SignaturePrivateKey()
 {}
 
 SignaturePrivateKey
-SignaturePrivateKey::generate(SignatureScheme scheme)
+SignaturePrivateKey::generate(CipherSuite suite)
 {
-  return SignaturePrivateKey(scheme, primitive::generate(scheme));
+  auto scheme = suite_signature_scheme(suite);
+  return SignaturePrivateKey(suite, primitive::generate(scheme));
 }
 
 SignaturePrivateKey
-SignaturePrivateKey::parse(SignatureScheme scheme, const bytes& data)
+SignaturePrivateKey::parse(CipherSuite suite, const bytes& data)
 {
-  return SignaturePrivateKey(scheme, data);
+  return SignaturePrivateKey(suite, data);
 }
 
 SignaturePrivateKey
-SignaturePrivateKey::derive(SignatureScheme scheme, const bytes& secret)
+SignaturePrivateKey::derive(CipherSuite suite, const bytes& secret)
 {
-  return SignaturePrivateKey(scheme, primitive::derive(scheme, secret));
+  auto scheme = suite_signature_scheme(suite);
+  return SignaturePrivateKey(suite, primitive::derive(scheme, secret));
 }
 
 bytes
@@ -476,14 +484,14 @@ SignaturePrivateKey::sign(const bytes& message) const
 SignaturePublicKey
 SignaturePrivateKey::public_key() const
 {
-  return SignaturePublicKey(_scheme, _pub_data);
+  return SignaturePublicKey(_suite, _pub_data);
 }
 
-SignaturePrivateKey::SignaturePrivateKey(SignatureScheme scheme,
-                                         const bytes& data)
-  : _scheme(scheme)
+SignaturePrivateKey::SignaturePrivateKey(CipherSuite suite, const bytes& data)
+  : _suite(suite)
+  , _scheme(suite_signature_scheme(suite))
   , _data(data)
-  , _pub_data(primitive::priv_to_pub(scheme, data))
+  , _pub_data(primitive::priv_to_pub(_scheme, data))
 {}
 
 } // namespace mls

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -215,20 +215,20 @@ static std::tuple<HPKEKEMID, HPKEKDFID, HPKEAEADID>
 hpke_suite(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
       return std::make_tuple(
         HPKEKEMID::DHKEM_P256, HPKEKDFID::HKDF_SHA256, HPKEAEADID::AES_GCM_128);
 
-    case CipherSuite::P521_SHA512_AES256GCM:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
       return std::make_tuple(
         HPKEKEMID::DHKEM_P521, HPKEKDFID::HKDF_SHA512, HPKEAEADID::AES_GCM_256);
 
-    case CipherSuite::X25519_SHA256_AES128GCM:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
       return std::make_tuple(HPKEKEMID::DHKEM_X25519,
                              HPKEKDFID::HKDF_SHA256,
                              HPKEAEADID::AES_GCM_128);
 
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return std::make_tuple(
         HPKEKEMID::DHKEM_X448, HPKEKDFID::HKDF_SHA512, HPKEAEADID::AES_GCM_256);
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -17,12 +17,14 @@ GroupInfo::GroupInfo(bytes group_id_in,
                      TreeKEMPublicKey tree_in,
                      bytes confirmed_transcript_hash_in,
                      bytes interim_transcript_hash_in,
+                     ExtensionList extensions_in,
                      bytes confirmation_in)
   : group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , tree(std::move(tree_in))
   , confirmed_transcript_hash(std::move(confirmed_transcript_hash_in))
   , interim_transcript_hash(std::move(interim_transcript_hash_in))
+  , extensions(std::move(extensions_in))
   , confirmation(std::move(confirmation_in))
 {}
 

--- a/src/primitives.cpp
+++ b/src/primitives.cpp
@@ -139,12 +139,12 @@ static const EVP_MD*
 openssl_digest_type(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
-    case CipherSuite::X25519_SHA256_AES128GCM:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
       return EVP_sha256();
 
-    case CipherSuite::P521_SHA512_AES256GCM:
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return EVP_sha512();
 
     default:
@@ -253,12 +253,12 @@ static const EVP_CIPHER*
 openssl_cipher(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
-    case CipherSuite::X25519_SHA256_AES128GCM:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
       return EVP_aes_128_gcm();
 
-    case CipherSuite::P521_SHA512_AES256GCM:
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return EVP_aes_256_gcm();
 
     default:
@@ -270,10 +270,10 @@ static size_t
 openssl_tag_size(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
-    case CipherSuite::P521_SHA512_AES256GCM:
-    case CipherSuite::X25519_SHA256_AES128GCM:
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return 16;
 
     default:
@@ -407,13 +407,13 @@ OpenSSLKeyType
 ossl_key_type(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
       return OpenSSLKeyType::P256;
-    case CipherSuite::P521_SHA512_AES256GCM:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
       return OpenSSLKeyType::P521;
-    case CipherSuite::X25519_SHA256_AES128GCM:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
       return OpenSSLKeyType::X25519;
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return OpenSSLKeyType::X448;
     default:
       throw InvalidParameterError("Unknown ciphersuite");
@@ -729,15 +729,16 @@ public:
 
   void set_secret(const bytes& data) override
   {
+    // Choose a suite that will result in the right hash algorithm
     CipherSuite ersatz_suite;
     switch (static_cast<RawKeyType>(_type)) {
       case RawKeyType::X25519:
       case RawKeyType::Ed25519:
-        ersatz_suite = CipherSuite::P256_SHA256_AES128GCM;
+        ersatz_suite = CipherSuite::P256_AES128GCM_SHA256_P256;
         break;
       case RawKeyType::X448:
       case RawKeyType::Ed448:
-        ersatz_suite = CipherSuite::P521_SHA512_AES256GCM;
+        ersatz_suite = CipherSuite::P521_AES256GCM_SHA512_P521;
         break;
       default:
         throw InvalidParameterError("set_secret not supported");
@@ -863,13 +864,14 @@ public:
 
   void set_secret(const bytes& data) override
   {
+    // Choose a suite that will result in the right hash algorithm
     CipherSuite ersatz_suite;
     switch (static_cast<ECKeyType>(_curve_nid)) {
       case ECKeyType::P256:
-        ersatz_suite = CipherSuite::P256_SHA256_AES128GCM;
+        ersatz_suite = CipherSuite::P256_AES128GCM_SHA256_P256;
         break;
       case ECKeyType::P521:
-        ersatz_suite = CipherSuite::P521_SHA512_AES256GCM;
+        ersatz_suite = CipherSuite::P521_AES256GCM_SHA512_P521;
         break;
       default:
         throw InvalidParameterError("set_secret not supported");

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -114,6 +114,24 @@ State::sign(const Proposal& proposal) const
 MLSPlaintext
 State::add(const KeyPackage& key_package) const
 {
+  // Check that the key package is validly signed
+  if (!key_package.verify()) {
+    throw InvalidParameterError("Invalid signature on key package");
+  }
+
+  // Check that the group's basic properties are supported
+  auto version = ProtocolVersion::mls10;
+  auto now = seconds_since_epoch();
+  if (!key_package.verify_basic_extensions(version, _suite, now)) {
+    throw InvalidParameterError("Basic extensions invalid");
+  }
+
+  // Check that the group's extensions are supported
+  if (!key_package.verify_extension_support(_extensions)) {
+    throw InvalidParameterError(
+      "Key package does not support group's extensions");
+  }
+
   return sign({ Add{ key_package } });
 }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -191,6 +191,7 @@ State::commit(const bytes& leaf_secret) const
     next._tree,
     next._confirmed_transcript_hash,
     next._interim_transcript_hash,
+    next._extensions,
     std::get<CommitData>(pt.content).confirmation,
   };
   group_info.sign(_index, _identity_priv);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -120,10 +120,9 @@ State::add(const KeyPackage& key_package) const
   }
 
   // Check that the group's basic properties are supported
-  auto version = ProtocolVersion::mls10;
   auto now = seconds_since_epoch();
-  if (!key_package.verify_basic_extensions(version, _suite, now)) {
-    throw InvalidParameterError("Basic extensions invalid");
+  if (!key_package.verify_expiry(now)) {
+    throw InvalidParameterError("Expired key package");
   }
 
   // Check that the group's extensions are supported

--- a/test/credential_test.cpp
+++ b/test/credential_test.cpp
@@ -5,10 +5,10 @@ using namespace mls;
 
 TEST(CredentialTest, Basic)
 {
-  auto scheme = SignatureScheme::P256_SHA256;
+  auto suite = CipherSuite::P256_AES128GCM_SHA256_P256;
 
   auto user_id = bytes{ 0x00, 0x01, 0x02, 0x03 };
-  auto priv = SignaturePrivateKey::generate(scheme);
+  auto priv = SignaturePrivateKey::generate(suite);
   auto pub = priv.public_key();
 
   auto cred = Credential::basic(user_id, pub);

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -5,9 +5,6 @@
 
 using namespace mls;
 
-#define CIPHERSUITE CipherSuite::P256_SHA256_AES128GCM
-#define SIG_SCHEME SignatureScheme::P256_SHA256
-
 class CryptoTest : public ::testing::Test
 {
 protected:
@@ -216,8 +213,8 @@ TEST_F(CryptoTest, Interop)
 
 TEST_F(CryptoTest, SHA2)
 {
-  auto suite256 = CipherSuite::P256_SHA256_AES128GCM;
-  auto suite512 = CipherSuite::P521_SHA512_AES256GCM;
+  auto suite256 = CipherSuite::P256_AES128GCM_SHA256_P256;
+  auto suite512 = CipherSuite::P521_AES256GCM_SHA512_P521;
 
   CryptoMetrics::reset();
   ASSERT_EQ(Digest(suite256).write(sha2_in).digest(), sha256_out);
@@ -232,7 +229,7 @@ TEST_F(CryptoTest, SHA2)
 
 TEST_F(CryptoTest, AES128GCM)
 {
-  auto suite = CipherSuite::P256_SHA256_AES128GCM;
+  auto suite = CipherSuite::P256_AES128GCM_SHA256_P256;
 
   auto encrypted = primitive::seal(
     suite, aes128gcm_key, aes128gcm_nonce, aes128gcm_aad, aes128gcm_pt);
@@ -256,7 +253,7 @@ TEST_F(CryptoTest, AES128GCM)
 
 TEST_F(CryptoTest, AES256GCM)
 {
-  auto suite = CipherSuite::P521_SHA512_AES256GCM;
+  auto suite = CipherSuite::P521_AES256GCM_SHA512_P521;
 
   auto encrypted = primitive::seal(
     suite, aes256gcm_key, aes256gcm_nonce, aes256gcm_aad, aes256gcm_pt);
@@ -280,10 +277,10 @@ TEST_F(CryptoTest, AES256GCM)
 
 TEST_F(CryptoTest, BasicDH)
 {
-  std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
-                                   CipherSuite::P521_SHA512_AES256GCM,
-                                   CipherSuite::X25519_SHA256_AES128GCM,
-                                   CipherSuite::X448_SHA512_AES256GCM };
+  std::vector<CipherSuite> suites{ CipherSuite::P256_AES128GCM_SHA256_P256,
+                                   CipherSuite::P521_AES256GCM_SHA512_P521,
+                                   CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
+                                   CipherSuite::X448_AES256GCM_SHA512_Ed448 };
 
   for (auto suite : suites) {
     auto s = bytes{ 0, 1, 2, 3 };
@@ -321,10 +318,10 @@ TEST_F(CryptoTest, BasicDH)
 
 TEST_F(CryptoTest, DHSerialize)
 {
-  std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
-                                   CipherSuite::P521_SHA512_AES256GCM,
-                                   CipherSuite::X25519_SHA256_AES128GCM,
-                                   CipherSuite::X448_SHA512_AES256GCM };
+  std::vector<CipherSuite> suites{ CipherSuite::P256_AES128GCM_SHA256_P256,
+                                   CipherSuite::P521_AES256GCM_SHA512_P521,
+                                   CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
+                                   CipherSuite::X448_AES256GCM_SHA512_Ed448 };
 
   for (auto suite : suites) {
     auto x = HPKEPrivateKey::derive(suite, { 0, 1, 2, 3 });
@@ -340,7 +337,7 @@ TEST_F(CryptoTest, DHSerialize)
 
 TEST_F(CryptoTest, P256DH)
 {
-  auto suite = CipherSuite::P256_SHA256_AES128GCM;
+  auto suite = CipherSuite::P256_AES128GCM_SHA256_P256;
 
   auto pkA = primitive::priv_to_pub(suite, p256dh_skA);
   ASSERT_EQ(pkA, p256dh_pkA);
@@ -351,7 +348,7 @@ TEST_F(CryptoTest, P256DH)
 
 TEST_F(CryptoTest, P521DH)
 {
-  auto suite = CipherSuite::P521_SHA512_AES256GCM;
+  auto suite = CipherSuite::P521_AES256GCM_SHA512_P521;
 
   auto pkA = primitive::priv_to_pub(suite, p521dh_skA);
   ASSERT_EQ(pkA, p521dh_pkA);
@@ -362,7 +359,7 @@ TEST_F(CryptoTest, P521DH)
 
 TEST_F(CryptoTest, X25519)
 {
-  auto suite = CipherSuite::X25519_SHA256_AES128GCM;
+  auto suite = CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
 
   auto pkA = primitive::priv_to_pub(suite, x25519_skA);
   auto pkB = primitive::priv_to_pub(suite, x25519_skB);
@@ -377,7 +374,7 @@ TEST_F(CryptoTest, X25519)
 
 TEST_F(CryptoTest, X448)
 {
-  auto suite = CipherSuite::X448_SHA512_AES256GCM;
+  auto suite = CipherSuite::X448_AES256GCM_SHA512_Ed448;
 
   auto pkA = primitive::priv_to_pub(suite, x448_skA);
   auto pkB = primitive::priv_to_pub(suite, x448_skB);
@@ -392,10 +389,10 @@ TEST_F(CryptoTest, X448)
 
 TEST_F(CryptoTest, HPKE)
 {
-  std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
-                                   CipherSuite::P521_SHA512_AES256GCM,
-                                   CipherSuite::X25519_SHA256_AES128GCM,
-                                   CipherSuite::X448_SHA512_AES256GCM };
+  std::vector<CipherSuite> suites{ CipherSuite::P256_AES128GCM_SHA256_P256,
+                                   CipherSuite::P521_AES256GCM_SHA512_P521,
+                                   CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
+                                   CipherSuite::X448_AES256GCM_SHA512_Ed448 };
 
   auto aad = random_bytes(100);
   auto original = random_bytes(100);

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -68,20 +68,18 @@ TEST_F(MessagesTest, Extensions)
 TEST_F(MessagesTest, Interop)
 {
   for (const auto& tc : tv.cases) {
-    auto reproducible = deterministic_signature_scheme(tc.signature_scheme);
+    auto reproducible = deterministic_signature_scheme(tc.cipher_suite);
 
     // Miscellaneous data items we need to construct messages
     auto dh_priv = HPKEPrivateKey::derive(tc.cipher_suite, tv.dh_seed);
     auto dh_key = dh_priv.public_key();
-    auto sig_priv =
-      SignaturePrivateKey::derive(tc.signature_scheme, tv.sig_seed);
+    auto sig_priv = SignaturePrivateKey::derive(tc.cipher_suite, tv.sig_seed);
     auto sig_key = sig_priv.public_key();
     auto cred = Credential::basic(tv.user_id, sig_priv.public_key());
 
     DeterministicHPKE lock;
     auto tree =
       TestTreeKEMPublicKey{ tc.cipher_suite,
-                            tc.signature_scheme,
                             { tv.random, tv.random, tv.random, tv.random } };
     tree.blank_path(LeafIndex{ 2 });
 

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -92,15 +92,17 @@ TEST_F(MessagesTest, Interop)
     direct_path.leaf_key_package.signature = tv.random;
 
     // KeyPackage
-    KeyPackage key_package{
-      tc.cipher_suite, dh_priv.public_key(), cred, sig_priv
-    };
+    auto ext_list =
+      ExtensionList{ { { ExtensionType::lifetime, bytes(8, 0) } } };
+    auto key_package =
+      KeyPackage{ tc.cipher_suite, dh_priv.public_key(), cred, sig_priv };
+    key_package.extensions = ext_list;
     key_package.signature = tv.random;
     tls_round_trip(tc.key_package, key_package, reproducible);
 
     // GroupInfo, GroupSecrets, EncryptedGroupSecrets, and Welcome
-    auto group_info =
-      GroupInfo{ tv.group_id, tv.epoch, tree, tv.random, tv.random, tv.random };
+    auto group_info = GroupInfo{ tv.group_id, tv.epoch, tree,     tv.random,
+                                 tv.random,   ext_list, tv.random };
     group_info.signer_index = tv.signer_index;
     group_info.signature = tv.random;
     tls_round_trip(tc.group_info, group_info, true, tc.cipher_suite);

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -38,8 +38,8 @@ TEST_F(MessagesTest, Extensions)
 {
   auto sv0 = SupportedVersionsExtension{ { ProtocolVersion::mls10 } };
   auto sc0 = SupportedCipherSuitesExtension{ {
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   } };
   auto lt0 = LifetimeExtension{ 0xA0A0A0A0A0A0A0A0, 0xB0B0B0B0B0B0B0B0 };
   auto kid0 = KeyIDExtension{ { 0, 1, 2, 3 } };
@@ -52,11 +52,11 @@ TEST_F(MessagesTest, Extensions)
   exts.add(kid0);
   exts.add(ph0);
 
-  auto sv1 = exts.get<SupportedVersionsExtension>();
-  auto sc1 = exts.get<SupportedCipherSuitesExtension>();
-  auto lt1 = exts.get<LifetimeExtension>();
-  auto kid1 = exts.get<KeyIDExtension>();
-  auto ph1 = exts.get<ParentHashExtension>();
+  auto sv1 = exts.find<SupportedVersionsExtension>();
+  auto sc1 = exts.find<SupportedCipherSuitesExtension>();
+  auto lt1 = exts.find<LifetimeExtension>();
+  auto kid1 = exts.find<KeyIDExtension>();
+  auto ph1 = exts.find<ParentHashExtension>();
 
   ASSERT_EQ(sv0, sv1);
   ASSERT_EQ(sc0, sc1);

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -34,6 +34,37 @@ protected:
   {}
 };
 
+TEST_F(MessagesTest, Extensions)
+{
+  auto sv0 = SupportedVersionsExtension{ { ProtocolVersion::mls10 } };
+  auto sc0 = SupportedCipherSuitesExtension{ {
+    CipherSuite::P256_SHA256_AES128GCM,
+    CipherSuite::X25519_SHA256_AES128GCM,
+  } };
+  auto lt0 = LifetimeExtension{ 0xA0A0A0A0A0A0A0A0, 0xB0B0B0B0B0B0B0B0 };
+  auto kid0 = KeyIDExtension{ { 0, 1, 2, 3 } };
+  auto ph0 = ParentHashExtension{ { 4, 5, 6, 7 } };
+
+  ExtensionList exts;
+  exts.add(sv0);
+  exts.add(sc0);
+  exts.add(lt0);
+  exts.add(kid0);
+  exts.add(ph0);
+
+  auto sv1 = exts.get<SupportedVersionsExtension>();
+  auto sc1 = exts.get<SupportedCipherSuitesExtension>();
+  auto lt1 = exts.get<LifetimeExtension>();
+  auto kid1 = exts.get<KeyIDExtension>();
+  auto ph1 = exts.get<ParentHashExtension>();
+
+  ASSERT_EQ(sv0, sv1);
+  ASSERT_EQ(sc0, sc1);
+  ASSERT_EQ(lt0, lt1);
+  ASSERT_EQ(kid0, kid1);
+  ASSERT_EQ(ph0, ph1);
+}
+
 TEST_F(MessagesTest, Interop)
 {
   for (const auto& tc : tv.cases) {

--- a/test/session_test.cpp
+++ b/test/session_test.cpp
@@ -7,7 +7,7 @@ using namespace mls;
 class SessionTest : public ::testing::Test
 {
 protected:
-  const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
+  const CipherSuite suite = CipherSuite::P256_AES128GCM_SHA256_P256;
   const SignatureScheme scheme = SignatureScheme::Ed25519;
   const int group_size = 5;
   const size_t secret_size = 32;
@@ -147,8 +147,10 @@ TEST_F(SessionTest, CiphersuiteNegotiation)
   // Alice supports P-256 and X25519
   auto idA = new_identity_key();
   auto credA = Credential::basic(user_id, idA.public_key());
-  std::vector<CipherSuite> ciphersA{ CipherSuite::P256_SHA256_AES128GCM,
-                                     CipherSuite::X25519_SHA256_AES128GCM };
+  std::vector<CipherSuite> ciphersA{
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519
+  };
   std::vector<KeyPackage> kpsA;
   std::vector<Session::InitInfo> infosA;
   for (auto suiteA : ciphersA) {
@@ -163,8 +165,10 @@ TEST_F(SessionTest, CiphersuiteNegotiation)
   // Bob supports P-256 and P-521
   auto idB = new_identity_key();
   auto credB = Credential::basic(user_id, idB.public_key());
-  std::vector<CipherSuite> ciphersB{ CipherSuite::P256_SHA256_AES128GCM,
-                                     CipherSuite::X25519_SHA256_AES128GCM };
+  std::vector<CipherSuite> ciphersB{
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519
+  };
   std::vector<KeyPackage> kpsB;
   std::vector<Session::InitInfo> infosB;
   for (auto suiteB : ciphersB) {
@@ -182,7 +186,7 @@ TEST_F(SessionTest, CiphersuiteNegotiation)
   TestSession alice = std::get<0>(session_welcome_add);
   TestSession bob = Session::join(infosB, std::get<1>(session_welcome_add));
   ASSERT_EQ(alice, bob);
-  ASSERT_EQ(alice.cipher_suite(), CipherSuite::P256_SHA256_AES128GCM);
+  ASSERT_EQ(alice.cipher_suite(), CipherSuite::P256_AES128GCM_SHA256_P256);
 }
 
 class RunningSessionTest : public SessionTest

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -7,7 +7,7 @@ using namespace mls;
 class StateTest : public ::testing::Test
 {
 protected:
-  const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
+  const CipherSuite suite = CipherSuite::P256_AES128GCM_SHA256_P256;
   const SignatureScheme scheme = SignatureScheme::P256_SHA256;
 
   const size_t group_size = 5;

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -8,7 +8,6 @@ class StateTest : public ::testing::Test
 {
 protected:
   const CipherSuite suite = CipherSuite::P256_AES128GCM_SHA256_P256;
-  const SignatureScheme scheme = SignatureScheme::P256_SHA256;
 
   const size_t group_size = 5;
   const bytes group_id = { 0, 1, 2, 3 };
@@ -24,7 +23,7 @@ protected:
   {
     for (size_t i = 0; i < group_size; i += 1) {
       auto init_secret = random_bytes(32);
-      auto identity_priv = SignaturePrivateKey::generate(scheme);
+      auto identity_priv = SignaturePrivateKey::generate(suite);
       auto credential = Credential::basic(user_id, identity_priv.public_key());
       auto init_priv = HPKEPrivateKey::derive(suite, init_secret);
       auto key_package =

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -22,8 +22,9 @@ const std::string BasicSessionTestVectors::file_name = "./basic_session.bin";
 ///
 
 bool
-deterministic_signature_scheme(SignatureScheme scheme)
+deterministic_signature_scheme(CipherSuite suite)
 {
+  auto scheme = suite_signature_scheme(suite);
   switch (scheme) {
     case SignatureScheme::P256_SHA256:
       return false;

--- a/test/treekem_test.cpp
+++ b/test/treekem_test.cpp
@@ -10,7 +10,6 @@ class TreeKEMTest : public ::testing::Test
 {
 protected:
   const CipherSuite suite = CipherSuite::P256_AES128GCM_SHA256_P256;
-  const SignatureScheme scheme = SignatureScheme::Ed25519;
 
   const TreeKEMTestVectors tv;
 
@@ -23,7 +22,7 @@ protected:
   {
     auto init_secret = random_bytes(32);
     auto init_priv = HPKEPrivateKey::derive(suite, init_secret);
-    auto sig_priv = SignaturePrivateKey::generate(scheme);
+    auto sig_priv = SignaturePrivateKey::generate(suite);
     auto cred = Credential::basic({ 0, 1, 2, 3 }, sig_priv.public_key());
     auto kp = KeyPackage{ suite, init_priv.public_key(), cred, sig_priv };
     return std::make_tuple(init_secret, init_priv, sig_priv, kp);
@@ -284,8 +283,8 @@ TEST_F(TreeKEMTest, Interop)
       auto context = bytes{ uint8_t(i), uint8_t(j) };
       auto init_priv =
         HPKEPrivateKey::derive(tc.cipher_suite, tv.init_secrets[j].data);
-      auto sig_priv = SignaturePrivateKey::derive(tc.signature_scheme,
-                                                  tv.init_secrets[j].data);
+      auto sig_priv =
+        SignaturePrivateKey::derive(tc.cipher_suite, tv.init_secrets[j].data);
       auto cred = Credential::basic(context, sig_priv.public_key());
       auto kp =
         KeyPackage{ tc.cipher_suite, init_priv.public_key(), cred, sig_priv };

--- a/test/treekem_test.cpp
+++ b/test/treekem_test.cpp
@@ -9,7 +9,7 @@ using namespace mls;
 class TreeKEMTest : public ::testing::Test
 {
 protected:
-  const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
+  const CipherSuite suite = CipherSuite::P256_AES128GCM_SHA256_P256;
   const SignatureScheme scheme = SignatureScheme::Ed25519;
 
   const TreeKEMTestVectors tv;


### PR DESCRIPTION
Mirror of cisco mlspp#91
This PR adds basic support for extensions in all of the places currently defined: KeyPackage, GroupState, and Groupinfo.  API is available for setting extensions on KeyPackage objects, but not for setting extensions on groups.

Depends on #90.
